### PR TITLE
Use --first-parent when describing tags

### DIFF
--- a/git/utils.go
+++ b/git/utils.go
@@ -63,7 +63,7 @@ func Merges(revs ...string) ([]string, error) {
 // LastTag finds the last tag if it exists. If no tag can be found, then
 // this returns a blank string.
 func LastTag(revs ...string) (string, error) {
-	args := []string{"describe", "--abbrev=0", "--tags"}
+	args := []string{"describe", "--abbrev=0", "--tags", "--first-parent"}
 	if len(revs) > 0 {
 		args = append(args, revs...)
 	}


### PR DESCRIPTION
This prevents git from finding the wrong tag when a commit was created before a new tag and merged after a release.