### PR TITLE
fix: removed colon expectation from the breaking change

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -429,7 +429,7 @@ type Commit struct {
 // headerPattern matches the type, scope and description of a commit message header.
 var headerPattern = regexp.MustCompile(`^(\w+)(\([\w/]+\))?:(.+)$`)
 
-const breaking = "BREAKING CHANGE:"
+const breaking = "BREAKING CHANGE"
 
 func parseCommit(commit *object.Commit) (Commit, error) {
 	var (


### PR DESCRIPTION
issue: The breaking change was not showing up in the release notes as the changelog project was expecting a colon.
Here's the [commit message](https://github.com/influxdata/flux/pull/4809/commits/b86e9591b09cce85398732154b02fe59dacce0ea) that was missed.

to fix that I have removed the colon from the [expectation](https://github.com/influxdata/changelog/blob/master/cmd/generate.go#L464). 